### PR TITLE
FOODMATE #95 로그인 기능 구현

### DIFF
--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+// 로그인
+export const onSignIn = async (email: string, password: string) => {
+  try {
+    const result = await axios.post(`/api/member/signin`, {
+      email,
+      password,
+    });
+    return result.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -13,3 +13,23 @@ export const onSignIn = async (email: string, password: string) => {
     throw error;
   }
 };
+
+// 로그인된 유저 프로필
+export const signedMemberInfo = async () => {
+  try {
+    const result = await axios.get('/api/member');
+    return result.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 카카오로 로그인
+export const kakaoSignIn = async () => {
+  try {
+    const result = await axios.get('/api/oauth2/authorization/kakao');
+    return result.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -132,7 +132,7 @@ const Login: React.FC = () => {
   const successSignIn = async (refreshToken: string, accessToken: string) => {
     try {
       const expirationDate = new Date();
-      expirationDate.setDate(expirationDate.getDate() + 30);
+      expirationDate.setDate(expirationDate.getDate() + 14);
       (document.cookie = `refreshToken=${refreshToken}; expires=${expirationDate.toUTCString()}; path=/;`), [];
 
       sessionStorage.setItem('accessToken', accessToken);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,160 +1,182 @@
 import React from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { styled } from "styled-components";
-import kakao from "../assets/kakao_login.png"
+import { styled } from 'styled-components';
+import kakao from '../assets/kakao_login.png';
+import { onSignIn } from '../api/memberApi';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
 
 const LoginWrap = styled.div`
-    margin: 150px auto 0;
-    width: 350px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  margin: 150px auto 0;
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const LoginTitle = styled.h3`
-    font-size: 24px;
-    margin-bottom: 30px;
+  font-size: 24px;
+  margin-bottom: 30px;
 `;
 const InputWrap = styled.div`
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 
-    input{
-        width: 340px;
-        height: 54px;
-        border-radius: 8px;
-        border: 1px solid #ccc;
-        padding-left: 15px;
-    }
+  input {
+    width: 340px;
+    height: 54px;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+    padding-left: 15px;
+  }
 
-    p{
-        margin-top: 4px;
-        color: red;
-        font-size: 12px;
-        margin-left: 4px;
-    }
+  p {
+    margin-top: 4px;
+    color: red;
+    font-size: 12px;
+    margin-left: 4px;
+  }
 `;
 
 const LoginButton = styled.button`
-    width: 340px;
-    height: 54px;
-    padding: 8px 12px;
-    background-color: #FFCE00;
-    border: 1px solid #FFCE00;
-    color: #212121;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: 0.3s;
-    margin-bottom: 15px;
+  width: 340px;
+  height: 54px;
+  padding: 8px 12px;
+  background-color: #ffce00;
+  border: 1px solid #ffce00;
+  color: #212121;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.3s;
+  margin-bottom: 15px;
 `;
 
 const RegisterButton = styled.button`
-    width: 340px;
-    height: 54px;
-    padding: 8px 12px;
-    background-color: #ffffff;
-    border: 1px solid #FFCE00;
-    color: #212121;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: 0.3s;
-    margin-bottom: 30px;
+  width: 340px;
+  height: 54px;
+  padding: 8px 12px;
+  background-color: #ffffff;
+  border: 1px solid #ffce00;
+  color: #212121;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.3s;
+  margin-bottom: 30px;
 `;
 
 const SimpleWrap = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 
-    hr{
-        width: 95px;
-        border: 1px solid #ccc;
-    }
+  hr {
+    width: 95px;
+    border: 1px solid #ccc;
+  }
 
-    span{
-        width: 150px;
-        text-align: center;
-        font-size: 13px;
-        color: #212121;
-    }
+  span {
+    width: 150px;
+    text-align: center;
+    font-size: 13px;
+    color: #212121;
+  }
 `;
 
 const Kakao = styled.button`
-    background-image: url(${kakao});
-    width: 340px;
-    height: 45px;
-    margin-top: 15px;
-    border: 0;
-    background-repeat: no-repeat;
-    background-size: cover;
-    border-radius: 8px;
-    cursor:pointer;
+  background-image: url(${kakao});
+  width: 340px;
+  height: 45px;
+  margin-top: 15px;
+  border: 0;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-radius: 8px;
+  cursor: pointer;
 `;
 
 const PasswordFind = styled.a`
-    font-size: 13px;
-    color: #212121;
-    display: flex;
-    justify-content: flex-end;
-    text-decoration: none;
-    margin-right: 11px;
-    margin-top: 15px;
+  font-size: 13px;
+  color: #212121;
+  display: flex;
+  justify-content: flex-end;
+  text-decoration: none;
+  margin-right: 11px;
+  margin-top: 15px;
 `;
 
-type FormValues = {
+export type FormValues = {
   email: string;
   password: string;
 };
 
 const Login: React.FC = () => {
+  const navigate = useNavigate();
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<FormValues>();
-  const onSubmit: SubmitHandler<FormValues> = (data:FormValues) => console.log(data);
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    try {
+      const result = await onSignIn(data.email, data.password);
+      // const refreshToken = result.refreshToken;
+      const accessToken = result.accessToken;
+      localStorage.setItem('accessToken', accessToken);
+      axios.defaults.headers.common['Authorization'] = `${accessToken}`;
+      alert('로그인 되었습니다.');
+      navigate('/');
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response) {
+        alert(axiosError.response.data);
+      } else {
+        console.log('서버 응답 없음');
+      }
+    }
+  };
 
   return (
     <LoginWrap>
-        <LoginTitle>로그인</LoginTitle>
-        <form onSubmit={handleSubmit(onSubmit)}>
-            <InputWrap>
-                <input
-                placeholder="이메일을 입력하세요"
-                {...register('email', { required: '이메일을 입력해주세요' })}
-                />
-                {errors.email && <p>{errors.email.message}</p>}
-            </InputWrap>
-            
-            <InputWrap>
-                <input
-                type="password"
-                placeholder="비밀번호를 입력해주세요"
-                {...register('password', {
-                    required: '비밀번호를 입력해주세요',
-                    minLength: {
-                    value: 6,
-                    message: '최소 6자 이상의 비밀번호를 입력해주세요',
-                    },
-                })}
-                />
-                {errors.password && <p>{errors.password.message}</p>}
-            </InputWrap>
-            <LoginButton>로그인</LoginButton>
-            <RegisterButton>회원가입</RegisterButton>
-            <SimpleWrap>
-                <hr></hr>
-                <span>간편로그인</span>
-                <hr></hr>
-            </SimpleWrap>
-            <Kakao></Kakao>
-            <PasswordFind href='#'>비밀번호 찾기</PasswordFind>
-        </form>
+      <LoginTitle>로그인</LoginTitle>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <InputWrap>
+          <input placeholder="이메일을 입력하세요" {...register('email', { required: '이메일을 입력해주세요' })} />
+          {errors.email && <p>{errors.email.message}</p>}
+        </InputWrap>
+
+        <InputWrap>
+          <input
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요',
+              minLength: {
+                value: 6,
+                message: '최소 6자 이상의 비밀번호를 입력해주세요',
+              },
+            })}
+          />
+          {errors.password && <p>{errors.password.message}</p>}
+        </InputWrap>
+        <LoginButton>로그인</LoginButton>
+        <Link to={'/register'}>
+          <RegisterButton>회원가입</RegisterButton>
+        </Link>
+        <SimpleWrap>
+          <hr></hr>
+          <span>간편로그인</span>
+          <hr></hr>
+        </SimpleWrap>
+        <Kakao></Kakao>
+        <PasswordFind href="#">비밀번호 찾기</PasswordFind>
+      </form>
     </LoginWrap>
   );
-}
+};
 
 export default Login;

--- a/src/store/groupAtoms.ts
+++ b/src/store/groupAtoms.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const signedUserInfo = atom({
+  key: 'signedUserInfo',
+  default: [],
+});


### PR DESCRIPTION
## 작업 목적
- 일반 로그인
- 카카오 로그인

## 작업 내용
- 일반 로그인, 카카오 로그인 API 연동
-  sessionStorage에 accessToken 저장
- cookie에 refreshToken 저장
- Authorization header 기본값 설정
- 회원가입 버튼 페이지 이동
- 유저 정보 atom에 저장


## 첨부
![image](https://github.com/withfoodmate/frontend/assets/85798544/0819e3dd-de5c-4ca6-ba05-f1d3be899c39)
![image](https://github.com/withfoodmate/frontend/assets/85798544/13735ee1-27ed-40e8-adc5-323c61300210)
![image](https://github.com/withfoodmate/frontend/assets/85798544/5ca38170-8883-412e-99dd-ed66b3f6e7b2)

## 관련된 이슈, 커밋, PR
- #95
- #47 

@wonmijin 
- CORS error 해결 후 카카오 로그인 잘 동작하는지 확인 부탁드려요.
- refreshToken 재요청 api url 생성되면 기능 추가해야 합니다.
- 카카오 로그인 버튼 클릭 시 해당 경고문 뜨지 않도록 해야 할 것 같아요.
![image](https://github.com/withfoodmate/frontend/assets/85798544/5b85a34c-9a4d-42ac-ad54-411aeecc2382)
- 비밀번호 찾기 구현 부탁드려요!

## 체크리스트

- [x] 빌드 테스트는 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 ISSUE나 PR을 포함했나요?
